### PR TITLE
improvement: handle cases when content is null

### DIFF
--- a/example/get_user_metadata.dart
+++ b/example/get_user_metadata.dart
@@ -27,7 +27,5 @@ void main() async {
     },
   );
 
-  requestStream.stream.listen((event) {
-    print(event);
-  });
+  requestStream.stream.listen(print);
 }

--- a/example/listening_to_events.dart
+++ b/example/listening_to_events.dart
@@ -54,7 +54,7 @@ void main() async {
 
     for (final a in event.tags!) {
       if (a.first == 'a') {
-        print(a.toString());
+        print(a);
       }
     }
   });

--- a/example/main.dart
+++ b/example/main.dart
@@ -24,7 +24,7 @@ Future<void> main() async {
     keyPairs: keyPair,
     tags: [
       ['t', currentDateInMsAsString],
-      ['title', "ps5"],
+      ['title', 'ps5'],
     ],
   );
 

--- a/example/sending_event_to_relays.dart
+++ b/example/sending_event_to_relays.dart
@@ -45,7 +45,7 @@ void main() async {
       ...relaysList,
     ],
     onOk: (relay, ok) {
-      print("second only");
+      print('second only');
     },
   );
 

--- a/lib/nostr/core/extensions.dart
+++ b/lib/nostr/core/extensions.dart
@@ -1,6 +1,5 @@
 extension RelaysListExt on List<String> {
   bool containsRelay(String relay) {
-
-    return this.contains(relay);
+    return contains(relay);
   }
 }

--- a/lib/nostr/core/utils.dart
+++ b/lib/nostr/core/utils.dart
@@ -1,19 +1,20 @@
 import 'dart:developer' as dev;
 
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:dart_nostr/nostr/dart_nostr.dart';
 import 'package:dart_nostr/nostr/model/debug_options.dart';
 
 /// {@template nostr_client_utils}
 /// General utils to be used in a whole [Nostr] instance.
 /// {@endtemplate}
 class NostrLogger {
-  final NostrDebugOptions passedDebugOptions;
-  late NostrDebugOptions _debugOptions;
-
   NostrLogger({
     required this.passedDebugOptions,
   }) {
     _debugOptions = passedDebugOptions;
   }
+  final NostrDebugOptions passedDebugOptions;
+  late NostrDebugOptions _debugOptions;
 
   NostrDebugOptions get debugOptions => _debugOptions;
 

--- a/lib/nostr/instance/registry.dart
+++ b/lib/nostr/instance/registry.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dart_nostr/nostr/core/exceptions.dart';
 import 'package:dart_nostr/nostr/core/utils.dart';
 import 'package:dart_nostr/nostr/model/count.dart';

--- a/lib/nostr/instance/relays/relays.dart
+++ b/lib/nostr/instance/relays/relays.dart
@@ -1,16 +1,17 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:dart_nostr/dart_nostr.dart';
 import 'package:dart_nostr/nostr/core/extensions.dart';
+import 'package:dart_nostr/nostr/instance/registry.dart';
 import 'package:dart_nostr/nostr/instance/relays/base/relays.dart';
+import 'package:dart_nostr/nostr/instance/streams.dart';
+import 'package:dart_nostr/nostr/instance/web_sockets.dart';
 import 'package:dart_nostr/nostr/model/ease.dart';
 import 'package:dart_nostr/nostr/model/ok.dart';
 import 'package:dart_nostr/nostr/model/relay.dart';
 import 'package:dart_nostr/nostr/model/relay_informations.dart';
-import 'package:dart_nostr/nostr/instance/registry.dart';
-import 'package:dart_nostr/nostr/instance/streams.dart';
-import 'package:dart_nostr/nostr/instance/web_sockets.dart';
 import 'package:http/http.dart' as http;
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -108,8 +109,10 @@ class NostrRelays implements NostrRelaysBase {
       WebSocketChannel? relayWebSocket,
     )? onRelayListening,
     void Function(
-            String relayUrl, Object? error, WebSocketChannel? relayWebSocket)?
-        onRelayConnectionError,
+      String relayUrl,
+      Object? error,
+      WebSocketChannel? relayWebSocket,
+    )? onRelayConnectionError,
     void Function(String relayUrl, WebSocketChannel? relayWebSocket)?
         onRelayConnectionDone,
     bool lazyListeningToRelays = false,
@@ -301,7 +304,7 @@ class NostrRelays implements NostrRelaysBase {
         final serialized = countEvent.serialized();
         relay.socket.sink.add(serialized);
         logger.log(
-          'count event with subscription id: ${countEvent.subscriptionId} is sent to relay with url: ${relayUrl}',
+          'count event with subscription id: ${countEvent.subscriptionId} is sent to relay with url: $relayUrl',
         );
       }
     });
@@ -346,7 +349,7 @@ class NostrRelays implements NostrRelaysBase {
 
           relay.socket.sink.add(serialized);
           logger.log(
-            'request with subscription id: ${request.subscriptionId} is sent to relay with url: ${relayUrl}',
+            'request with subscription id: ${request.subscriptionId} is sent to relay with url: $relayUrl',
           );
         }
       });
@@ -519,8 +522,10 @@ class NostrRelays implements NostrRelaysBase {
     required bool ignoreConnectionException,
     required bool lazyListeningToRelays,
     void Function(
-            String relay, WebSocketChannel? relayWebSocket, NostrNotice notice)?
-        onNoticeMessageFromRelay,
+      String relay,
+      WebSocketChannel? relayWebSocket,
+      NostrNotice notice,
+    )? onNoticeMessageFromRelay,
   }) {
     final relayWebSocket = nostrRegistry.getRelayWebSocket(relayUrl: relay);
 

--- a/lib/nostr/instance/streams.dart
+++ b/lib/nostr/instance/streams.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:dart_nostr/nostr/dart_nostr.dart';
 import 'package:dart_nostr/nostr/model/export.dart';
 
 /// {@template nostr_streams_controllers}

--- a/lib/nostr/model/debug_options.dart
+++ b/lib/nostr/model/debug_options.dart
@@ -4,6 +4,17 @@ class NostrDebugOptions {
     this.isLogsEnabled = true,
   });
 
+  factory NostrDebugOptions.general() {
+    return NostrDebugOptions(
+      tag: 'Nostr',
+    );
+  }
+  factory NostrDebugOptions.generate() {
+    return NostrDebugOptions(
+      tag: _incrementallyGenerateTag(),
+    );
+  }
+
   static var _incrementalNumber = 0;
 
   bool isLogsEnabled = true;
@@ -14,17 +25,6 @@ class NostrDebugOptions {
     _incrementalNumber++;
 
     return '$_incrementalNumber - Nostr';
-  }
-
-  factory NostrDebugOptions.general() {
-    return NostrDebugOptions(
-      tag: 'Nostr',
-    );
-  }
-  factory NostrDebugOptions.generate() {
-    return NostrDebugOptions(
-      tag: _incrementallyGenerateTag(),
-    );
   }
 
   NostrDebugOptions copyWith({

--- a/lib/nostr/model/event/event.dart
+++ b/lib/nostr/model/event/event.dart
@@ -51,7 +51,6 @@ class NostrEvent extends Equatable {
             .toList(),
       ),
       subscriptionId: decoded[1] as String?,
-
     );
   }
 
@@ -75,7 +74,6 @@ class NostrEvent extends Equatable {
 
   /// The tags of the event.
   final List<List<String>>? tags;
-
 
   /// The subscription id of the event
   /// This is meant for events that are got from the relays, and not for events that are created by you.
@@ -143,7 +141,6 @@ class NostrEvent extends Equatable {
       pubkey: pubkey,
       createdAt: createdAtToUse,
       tags: tagsToUse,
-
     );
   }
 
@@ -171,7 +168,7 @@ class NostrEvent extends Equatable {
       );
     }
 
- if (id == null) {
+    if (id == null) {
       throw Exception(
         "You can't get a unique key for an event that you created, you can only get a unique key for an event that you got from the relays",
       );
@@ -192,24 +189,30 @@ class NostrEvent extends Equatable {
   /// Returns a map representation of this event.
   Map<String, dynamic> toMap() {
     return {
-       if (id != null) 'id': id,
+      if (id != null) 'id': id,
       if (kind != null) 'kind': kind,
-       'pubkey': pubkey,
+      'pubkey': pubkey,
       if (content != null) 'content': content,
       if (sig != null) 'sig': sig,
-      if (createdAt != null) 'created_at': createdAt!.millisecondsSinceEpoch ~/ 1000,
-      if (tags != null) 'tags': tags!.map((tag) => tag.map((e) => e).toList()).toList(), 
-      };
+      if (createdAt != null)
+        'created_at': createdAt!.millisecondsSinceEpoch ~/ 1000,
+      if (tags != null)
+        'tags': tags!.map((tag) => tag.map((e) => e).toList()).toList(),
+    };
   }
 
- bool isVerified() {
-    if(id == null || sig == null) {
+  bool isVerified() {
+    if (id == null || sig == null) {
       return false;
     }
 
-    return NostrKeyPairs.verify(pubkey, id!, sig!,  );
- }
- 
+    return NostrKeyPairs.verify(
+      pubkey,
+      id!,
+      sig!,
+    );
+  }
+
   @override
   List<Object?> get props => [
         id,

--- a/lib/nostr/model/event/event.dart
+++ b/lib/nostr/model/event/event.dart
@@ -26,14 +26,14 @@ class NostrEvent extends Equatable {
   /// This represents a nostr event that is received from the relays,
   /// it takes directly the relay message which is serialized, and handles all internally
   factory NostrEvent.deserialized(String data) {
-    assert(NostrEvent.canBeDeserialized(data));
+    assert(NostrEvent.canBeDeserialized(data), 'Event is not json-decodable');
     final decoded = jsonDecode(data) as List;
 
     final event = decoded.last as Map<String, dynamic>;
     return NostrEvent(
       id: event['id'] as String,
       kind: event['kind'] as int,
-      content: event['content'] as String,
+      content: event['content'] == null ? '' : event['content'] as String,
       sig: event['sig'] as String,
       pubkey: event['pubkey'] as String,
       createdAt: DateTime.fromMillisecondsSinceEpoch(

--- a/lib/nostr/model/relay.dart
+++ b/lib/nostr/model/relay.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 
+import 'dart:io';
+
 import 'package:equatable/equatable.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 

--- a/lib/nostr/model/request/filter.dart
+++ b/lib/nostr/model/request/filter.dart
@@ -114,7 +114,7 @@ class NostrFilter extends Equatable {
       if (until != null) 'until': until!.millisecondsSinceEpoch ~/ 1000,
       if (limit != null) 'limit': limit,
       if (search != null) 'search': search,
-      if (additionalFilters != null) ...additionalFilters!
+      if (additionalFilters != null) ...additionalFilters!,
     };
   }
 

--- a/lib/nostr/service/services.dart
+++ b/lib/nostr/service/services.dart
@@ -5,11 +5,10 @@ import 'package:dart_nostr/nostr/instance/relays/relays.dart';
 import 'package:dart_nostr/nostr/instance/utils/utils.dart';
 
 class NostrServices {
-  final NostrLogger logger;
-
   NostrServices({
     required this.logger,
   });
+  final NostrLogger logger;
 
   /// {@macro nostr_keys}
   late final keys = NostrKeys(

--- a/test/model/event/nostr_event_test.dart
+++ b/test/model/event/nostr_event_test.dart
@@ -1,0 +1,93 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  const validInput = '''
+[
+    "EVENT",
+    "subscriptionId",
+    {
+        "id": "identifier",
+        "pubkey": "author",
+        "kind": 0,
+        "created_at": 1740549558,
+        "tags": [
+            [
+                "p",
+                "pubkey"
+            ]
+        ],
+        "content": "content",
+        "sig": "event signature"
+    }
+]
+''';
+
+  const inputWithNullContent = '''
+ [
+    "EVENT",
+    "subscriptionId",
+    {
+        "id": "identifier",
+        "pubkey": "author",
+        "kind": 0,
+        "created_at": 1740549558,
+        "tags": [
+            [
+                "p",
+                "pubkey"
+            ]
+        ],
+        "content": null,
+        "sig": "event signature"
+    }
+]
+''';
+
+  final parsedEvent = NostrEvent(
+    content: 'content',
+    createdAt: DateTime.fromMillisecondsSinceEpoch(1740549558 * 1000),
+    id: 'identifier',
+    kind: 0,
+    pubkey: 'author',
+    sig: 'event signature',
+    subscriptionId: 'subscriptionId',
+    tags: const [
+      [
+        'p',
+        'pubkey',
+      ]
+    ],
+  );
+
+  final parsedEventWithNullContent = NostrEvent(
+    content: '',
+    createdAt: DateTime.fromMillisecondsSinceEpoch(1740549558 * 1000),
+    id: 'identifier',
+    kind: 0,
+    pubkey: 'author',
+    subscriptionId: 'subscriptionId',
+    sig: 'event signature',
+    tags: const [
+      [
+        'p',
+        'pubkey',
+      ]
+    ],
+  );
+
+  group('NostrEvent model test', () {
+    test('event is correctly parsed from payload', () {
+      final eventFromPayload = NostrEvent.deserialized(validInput);
+
+      expect(eventFromPayload, parsedEvent);
+    });
+
+    test('event is correctly parsed when content is null', () {
+      final eventFromPayload = NostrEvent.deserialized(inputWithNullContent);
+
+      expect(parsedEventWithNullContent, eventFromPayload);
+    });
+  });
+}


### PR DESCRIPTION
This pull requests includes following changes:
- results of execution `dart format` and `dart fix` 
- `content` field in `NostrEvent` is correctly parsed even when relay has sent `null` value
- tests for parsing `NostrEvent` model with support of nullable `content`