### PR TITLE
fix: parallel relay connections with per-relay timeout

### DIFF
--- a/lib/nostr/instance/relays/relays.dart
+++ b/lib/nostr/instance/relays/relays.dart
@@ -755,33 +755,30 @@ class NostrRelays implements NostrRelaysBase {
     required bool lazyListeningToRelays,
     bool relayUnregistered = true,
   }) async {
-    final completer = Completer();
-
     if (relaysList == null || relaysList!.isEmpty) {
       throw Exception(
         'you need to call the init method before calling this method.',
       );
     }
 
-    for (final relay in relaysList!) {
-      await _reconnectToRelay(
-        relayUnregistered: relayUnregistered,
-        relay: relay,
-        onRelayListening: onRelayListening,
-        onRelayConnectionError: onRelayConnectionError,
-        onRelayConnectionDone: onRelayConnectionDone,
-        retryOnError: retryOnError,
-        retryOnClose: retryOnClose,
-        shouldReconnectToRelayOnNotice: shouldReconnectToRelayOnNotice,
-        connectionTimeout: connectionTimeout,
-        ignoreConnectionException: ignoreConnectionException,
-        lazyListeningToRelays: lazyListeningToRelays,
-      );
-    }
-
-    completer.complete();
-
-    return completer.future;
+    await Future.wait(
+      relaysList!.map((relay) async {
+        await _reconnectToRelay(
+          relayUnregistered: relayUnregistered,
+          relay: relay,
+          onRelayListening: onRelayListening,
+          onRelayConnectionError: onRelayConnectionError,
+          onRelayConnectionDone: onRelayConnectionDone,
+          retryOnError: retryOnError,
+          retryOnClose: retryOnClose,
+          shouldReconnectToRelayOnNotice: shouldReconnectToRelayOnNotice,
+          connectionTimeout: connectionTimeout,
+          ignoreConnectionException: ignoreConnectionException,
+          lazyListeningToRelays: lazyListeningToRelays,
+        );
+      }),
+      eagerError: false,
+    );
   }
 
   Future<bool> disconnectFromRelays({
@@ -927,56 +924,57 @@ class NostrRelays implements NostrRelaysBase {
     required bool shouldReconnectToRelayOnNotice,
     required Duration connectionTimeout,
   }) async {
-    final completer = Completer();
-
-    for (final relay in relaysUrl) {
+    final relaysToConnect = relaysUrl.where((relay) {
       if (nostrRegistry.isRelayRegisteredAndConnectedSuccesfully(relay)) {
         logger.log(
           'relay with url: $relay is already connected successfully, skipping...',
         );
-
-        continue;
+        return false;
       }
+      return true;
+    }).toList();
 
-      try {
-        await webSocketsService.connectRelay(
-          relay: relay,
-          onConnectionSuccess: (relayWebSocket) {
-            nostrRegistry.registerRelayWebSocket(
-              relayUrl: relay,
-              webSocket: relayWebSocket,
-            );
-            logger.log(
-              'the websocket for the relay with url: $relay, is registered.',
-            );
-            logger.log(
-              'listening to the websocket for the relay with url: $relay...',
-            );
-
-            if (!lazyListeningToRelays) {
-              startListeningToRelay(
-                relay: relay,
-                onRelayListening: onRelayListening,
-                onRelayConnectionError: onRelayConnectionError,
-                onRelayConnectionDone: onRelayConnectionDone,
-                retryOnError: retryOnError,
-                retryOnClose: retryOnClose,
-                shouldReconnectToRelayOnNotice: shouldReconnectToRelayOnNotice,
-                connectionTimeout: connectionTimeout,
-                ignoreConnectionException: ignoreConnectionException,
-                lazyListeningToRelays: lazyListeningToRelays,
+    await Future.wait(
+      relaysToConnect.map((relay) async {
+        try {
+          await webSocketsService.connectRelay(
+            relay: relay,
+            connectTimeout: connectionTimeout,
+            onConnectionSuccess: (relayWebSocket) {
+              nostrRegistry.registerRelayWebSocket(
+                relayUrl: relay,
+                webSocket: relayWebSocket,
               );
-            }
-          },
-        );
-      } catch (e) {
-        onRelayConnectionError?.call(relay, e, null);
-      }
-    }
+              logger.log(
+                'the websocket for the relay with url: $relay, is registered.',
+              );
+              logger.log(
+                'listening to the websocket for the relay with url: $relay...',
+              );
 
-    completer.complete();
-
-    return completer.future;
+              if (!lazyListeningToRelays) {
+                startListeningToRelay(
+                  relay: relay,
+                  onRelayListening: onRelayListening,
+                  onRelayConnectionError: onRelayConnectionError,
+                  onRelayConnectionDone: onRelayConnectionDone,
+                  retryOnError: retryOnError,
+                  retryOnClose: retryOnClose,
+                  shouldReconnectToRelayOnNotice:
+                      shouldReconnectToRelayOnNotice,
+                  connectionTimeout: connectionTimeout,
+                  ignoreConnectionException: ignoreConnectionException,
+                  lazyListeningToRelays: lazyListeningToRelays,
+                );
+              }
+            },
+          );
+        } catch (e) {
+          onRelayConnectionError?.call(relay, e, null);
+        }
+      }),
+      eagerError: false,
+    );
   }
 
   bool _filterNostrEventsWithId(

--- a/lib/nostr/instance/web_sockets.dart
+++ b/lib/nostr/instance/web_sockets.dart
@@ -1,4 +1,5 @@
 import 'package:dart_nostr/nostr/core/utils.dart';
+import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 /// {@template nostr_web_sockets_service}
@@ -19,16 +20,23 @@ class NostrWebSocketsService {
   }
 
   /// Connects to a [relay] web socket, and trigger the [onConnectionSuccess] callback if the connection is successful, or the [onConnectionError] callback if the connection fails.
+  ///
+  /// If [connectTimeout] is provided, the connection attempt will be aborted
+  /// after the specified duration. If not provided, falls back to the default
+  /// [_connectionTimeout] (5 seconds). This prevents a single unreachable relay
+  /// from blocking the entire connection process indefinitely.
   Future<void> connectRelay({
     required String relay,
+    Duration? connectTimeout,
     bool? shouldIgnoreConnectionException,
     void Function(WebSocketChannel webSocket)? onConnectionSuccess,
   }) async {
     WebSocketChannel? webSocket;
 
     try {
-      webSocket = WebSocketChannel.connect(
-        Uri.parse(relay),
+      webSocket = IOWebSocketChannel.connect(
+        relay,
+        connectTimeout: connectTimeout ?? _connectionTimeout,
       );
 
       await webSocket.ready;


### PR DESCRIPTION
This PR fixes relay connection blocking when one or more relays are unreachable.

Currently, `init()` connects to relays sequentially, and `connectRelay()` uses `WebSocketChannel.connect()` which has no timeout support. This means a single dead relay blocks the entire connection process for as long as the OS TCP timeout takes. The connectionTimeout parameter exists and is passed through `init()`, but it never actually reaches the WebSocket connection.

The fix:
  - Uses `IOWebSocketChannel.connect(connectTimeout)` so each relay has an actual connection timeout
  - Replaces the sequential loop with `Future.wait()` so relays connect in parallel and a dead relay doesn't block the others
  - Applies the same change to `reconnectToRelays()`

For reference, the Rust equivalent (nostr-sdk/rust-nostr) already handles this correctly, it connects to relays in parallel with configurable per-relay timeouts.
